### PR TITLE
Get User from EF Core DBContext to fix tracking issues

### DIFF
--- a/Pages/CheckOut.razor
+++ b/Pages/CheckOut.razor
@@ -105,10 +105,11 @@
                 _skates = await Context.Skates.Where(s=> !s.IsArchived).OrderBy(s=>s.Name).ToListAsync();
                 //Get global properties
                 _properties = await Context.Properties.ToListAsync();
+                //Get Logged in User
+                var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+                user = await Context.Users.Where(u => u.UserName == authState.User.Identity.Name).FirstAsync();
             }
             
-            var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-            user = await UserManager.GetUserAsync(authState.User);
         }
         finally
         {

--- a/Pages/SkateAdmin.razor
+++ b/Pages/SkateAdmin.razor
@@ -110,6 +110,7 @@
 @code {
     private bool _busy, _hasLoaded;
     private List<Skate>? _skates;
+    private List<ApplicationUser>? _users;
     private string? _search;
     private List<Property>? _properties;
     private bool _addSkateModalVisible;
@@ -126,9 +127,11 @@
             _skates = await Context.Skates.OrderBy(s=>s.IsArchived).ThenBy(s => s.Name).ToListAsync();
             //Get global properties
             _properties = await Context.Properties.ToListAsync();
+            //Get all users
+            _users = await Context.Users.ToListAsync();
         }
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-        user = await UserManager.GetUserAsync(authState.User);
+        user = _users.FirstOrDefault(u => u.UserName == authState.User.Identity.Name);
         await base.OnInitializedAsync();
         _busy = false;
         _hasLoaded = true;
@@ -177,7 +180,7 @@
         AuditLog audit = new AuditLog() {
             Timestamp = DateTime.Now,
             Skate = skate,
-                User = user,
+            User = user,
             Action = $"Added new skate"
         };
         _skates.Add(skate);

--- a/Pages/SkateSharpening.razor
+++ b/Pages/SkateSharpening.razor
@@ -93,10 +93,10 @@
             _skates = await Context.Skates.Where(s=> !s.IsArchived).OrderBy(s=>s.MinutesUsed).ToListAsync();
             //Get global properties
             _properties = await Context.Properties.ToListAsync();
+            //Get logged in user
+            var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            user = await Context.Users.Where(u => u.UserName == authState.User.Identity.Name).FirstAsync();
         }
-
-        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-        user = await UserManager.GetUserAsync(authState.User);
 
         await base.OnInitializedAsync();
         _busy = false;

--- a/Pages/UserAdmin.razor
+++ b/Pages/UserAdmin.razor
@@ -205,7 +205,7 @@
         }
 
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-        loggedInUser = await UserManager.GetUserAsync(authState.User);
+        loggedInUser = _users.FirstOrDefault(u => u.UserName == authState.User.Identity.Name);
 
         await base.OnInitializedAsync();
         _busy = false;


### PR DESCRIPTION
Bug caused by using ApplicationUser from UserManager in new AuditLog caused EFCore to either attempt to recreate that user or  readd it to tracking since it wasn't previously tracked